### PR TITLE
refactor: Rename models

### DIFF
--- a/src/boltzmann_experimentation/dataset.py
+++ b/src/boltzmann_experimentation/dataset.py
@@ -11,7 +11,7 @@ class DatasetFactory:
     @staticmethod
     def create_dataset(model_type: MODEL_TYPE) -> tuple[Dataset, Dataset]:
         match model_type:
-            case "cifar10_cnn" | "resnet18" | "densenet" | "deit-b":
+            case "simple-cnn" | "resnet18" | "densenet" | "deit-b":
                 # Define data transformation (e.g., normalization)
                 if model_type == "deit-b":
                     transform = create_transform(

--- a/src/boltzmann_experimentation/dataset.py
+++ b/src/boltzmann_experimentation/dataset.py
@@ -3,7 +3,7 @@ from torch.utils.data import Dataset
 from torchvision import datasets, transforms
 
 from boltzmann_experimentation.model import MODEL_TYPE
-from boltzmann_experimentation.settings import general_settings, tiny_nn_settings
+from boltzmann_experimentation.settings import general_settings, perceptron_settings
 from timm.data import create_transform
 
 
@@ -41,9 +41,9 @@ class DatasetFactory:
                     root="./data", train=False, download=True, transform=transform
                 )
                 return train_dataset, val_dataset
-            case "tiny_nn" | "single-neuron-perceptron":
+            case "two-layer-perceptron" | "single-neuron-perceptron":
                 dataset = LinearRegressionDataset(
-                    general_settings.data_size, tiny_nn_settings.input_size
+                    general_settings.data_size, perceptron_settings.input_size
                 )
                 # Split dataset into training and validation sets
                 train_size = int(

--- a/src/boltzmann_experimentation/dataset.py
+++ b/src/boltzmann_experimentation/dataset.py
@@ -41,7 +41,7 @@ class DatasetFactory:
                     root="./data", train=False, download=True, transform=transform
                 )
                 return train_dataset, val_dataset
-            case "tiny_nn" | "two_neuron_network":
+            case "tiny_nn" | "single-neuron-perceptron":
                 dataset = LinearRegressionDataset(
                     general_settings.data_size, tiny_nn_settings.input_size
                 )

--- a/src/boltzmann_experimentation/experiment.py
+++ b/src/boltzmann_experimentation/experiment.py
@@ -85,6 +85,7 @@ def run(
             if same_model_init:
                 torch.manual_seed(SEED)
             model = ModelFactory.create_model(model_type)
+            general_logger.info(f"Model has {model.num_params()/1e6:.0f}M params.")
             if log_to_wandb:
                 wandb.finish()
                 run_name = f"Central training: {'Same Init' if same_model_init else 'Diff Init'}"

--- a/src/boltzmann_experimentation/model.py
+++ b/src/boltzmann_experimentation/model.py
@@ -30,7 +30,12 @@ class MinerSlice(BaseModel):
 
 
 MODEL_TYPE = Literal[
-    "two_neuron_network", "tiny_nn", "simple-cnn", "resnet18", "densenet", "deit-b"
+    "single-neuron-perceptron",
+    "tiny_nn",
+    "simple-cnn",
+    "resnet18",
+    "densenet",
+    "deit-b",
 ]
 
 
@@ -79,8 +84,8 @@ class ModelFactory:
                 torch_model = SimpleCNN()
                 criterion = nn.CrossEntropyLoss()
                 optimizer = optim.Adam(torch_model.parameters(), lr=0.001)
-            case "two_neuron_network":
-                torch_model = OneNeuronNetwork()
+            case "single-neuron-perceptron":
+                torch_model = SingleNeuronPerceptron()
                 criterion = nn.MSELoss()
                 optimizer = optim.SGD(torch_model.parameters(), lr=0.01)
                 return Model(
@@ -152,9 +157,9 @@ class TinyNeuralNetwork(nn.Module):
         return self.fc2(x)
 
 
-class OneNeuronNetwork(nn.Module):
+class SingleNeuronPerceptron(nn.Module):
     def __init__(self):
-        super(OneNeuronNetwork, self).__init__()
+        super(SingleNeuronPerceptron, self).__init__()
         self.linear = nn.Linear(1, 1)  # One input and one output
 
     def forward(self, x):

--- a/src/boltzmann_experimentation/model.py
+++ b/src/boltzmann_experimentation/model.py
@@ -30,7 +30,7 @@ class MinerSlice(BaseModel):
 
 
 MODEL_TYPE = Literal[
-    "two_neuron_network", "tiny_nn", "cifar10_cnn", "resnet18", "densenet", "deit-b"
+    "two_neuron_network", "tiny_nn", "simple-cnn", "resnet18", "densenet", "deit-b"
 ]
 
 
@@ -75,8 +75,8 @@ class ModelFactory:
                 optimizer = optim.Adam(
                     torch_model.parameters(), lr=0.001, weight_decay=1e-4
                 )
-            case "cifar10_cnn":
-                torch_model = CIFAR10CNN()
+            case "simple-cnn":
+                torch_model = SimpleCNN()
                 criterion = nn.CrossEntropyLoss()
                 optimizer = optim.Adam(torch_model.parameters(), lr=0.001)
             case "two_neuron_network":
@@ -117,9 +117,9 @@ class ModelFactory:
         )
 
 
-class CIFAR10CNN(nn.Module):
+class SimpleCNN(nn.Module):
     def __init__(self):
-        super(CIFAR10CNN, self).__init__()
+        super(SimpleCNN, self).__init__()
         self.conv1 = nn.Conv2d(3, 32, kernel_size=3, stride=1, padding=1)
         self.conv2 = nn.Conv2d(32, 64, kernel_size=3, stride=1, padding=1)
         self.fc1 = nn.Linear(64 * 8 * 8, 512)

--- a/src/boltzmann_experimentation/model.py
+++ b/src/boltzmann_experimentation/model.py
@@ -14,7 +14,10 @@ from torch.utils.data import DataLoader
 
 import wandb
 from boltzmann_experimentation.logger import general_logger, metrics_logger
-from boltzmann_experimentation.settings import tiny_nn_settings, general_settings as g
+from boltzmann_experimentation.settings import (
+    perceptron_settings,
+    general_settings as g,
+)
 
 
 class MinerSlice(BaseModel):
@@ -31,7 +34,7 @@ class MinerSlice(BaseModel):
 
 MODEL_TYPE = Literal[
     "single-neuron-perceptron",
-    "tiny_nn",
+    "two-layer-perceptron",
     "simple-cnn",
     "resnet18",
     "densenet",
@@ -93,11 +96,11 @@ class ModelFactory:
                     optimizer,
                     criterion,
                 )
-            case "tiny_nn":
-                torch_model = TinyNeuralNetwork(
-                    tiny_nn_settings.input_size,
-                    tiny_nn_settings.hidden_size,
-                    tiny_nn_settings.output_size,
+            case "two-layer-perceptron":
+                torch_model = TwoLayerPerceptron(
+                    perceptron_settings.input_size,
+                    perceptron_settings.hidden_size,
+                    perceptron_settings.output_size,
                 )
                 optimizer = optim.AdamW(torch_model.parameters(), lr=0.01)
                 criterion = nn.MSELoss()  # Mean squared error for regression
@@ -143,9 +146,9 @@ class SimpleCNN(nn.Module):
         return x
 
 
-class TinyNeuralNetwork(nn.Module):
+class TwoLayerPerceptron(nn.Module):
     def __init__(self, input_size, hidden_size, output_size):
-        super(TinyNeuralNetwork, self).__init__()
+        super(TwoLayerPerceptron, self).__init__()
         self.fc1 = nn.Linear(input_size, hidden_size)
         self.fc2 = nn.Linear(hidden_size, output_size)
         self.dropout = nn.Dropout(p=0.0)

--- a/src/boltzmann_experimentation/settings.py
+++ b/src/boltzmann_experimentation/settings.py
@@ -5,7 +5,7 @@ import torch
 from boltzmann_experimentation.literals import GPU_NUMBER
 
 
-class TinyNNSettings(BaseSettings):
+class PerceptronSettings(BaseSettings):
     hidden_size: int = 10000
     output_size: int = 1
     input_size: int = 1
@@ -48,6 +48,6 @@ class GeneralSettings(BaseSettings):
     log_to_wandb: bool = True
 
 
-tiny_nn_settings = TinyNNSettings()
+perceptron_settings = PerceptronSettings()
 general_settings = GeneralSettings()
 start_ts = datetime.now()


### PR DESCRIPTION
- **Log model size to stdout**
- **Rename `cifar10_cnn` to `simple-cnn`**
- **Rename `OneNeuronNetwork` to `SingleNeuronPerceptron`**
- **Rename `TinyNeuralNetwork` to `TwoLayerPerceptron`**
